### PR TITLE
Fix json credentials dict loading

### DIFF
--- a/oauth2_service.py
+++ b/oauth2_service.py
@@ -51,8 +51,6 @@ class OAuth2ServiceAccount(OAuth2Base):
                 headers=cred._generate_refresh_request_headers()
             )
         except Exception as e:
-            # raise OAuth2Exception("Could not complete request to {0}".format(
-            #     token_url))
             raise OAuth2Exception("Could not complete request to %s: %s %s %s"
                                   % (token_url, cred, key_info, e))
 

--- a/tests/test_service_account.py
+++ b/tests/test_service_account.py
@@ -14,7 +14,10 @@ class TestOAuth2ServiceAccount(NIOBlockTestCase):
 
     @patch.object(OAuth2ServiceAccount, '_load_json_file',
                   return_value={'client_email': 'foo@bar.gov',
-                                'private_key': 'WhatAKey'})
+                                'private_key': 'WhatAKey',
+                                'type': 'service_account',
+                                'private_key_id': 'WhatAnID',
+                                'client_id': 'WhatAClientID'})
     @patch('requests.post')
     @patch('oauth2client.service_account.ServiceAccountCredentials.'
            '_generate_refresh_request_body')


### PR DESCRIPTION
It looks like the switch from SignedJWTAssertionCredentials to ServiceAccountCredentials ended up with the wrong parameters being passed in to ServiceAccountCredentials. Using the built in method for reading from json credentials dicts fixed this. 
